### PR TITLE
Add basic anime support

### DIFF
--- a/backend/src/generateManifest.ts
+++ b/backend/src/generateManifest.ts
@@ -33,7 +33,7 @@ export default function generateManifest(
     logo: "https://eu.simkl.in/img_favicon/v2/favicon-192x192.png",
     catalogs,
     resources: ["catalog"],
-    types: ["movie", "series"],
+    types: ["movie", "series", "anime"],
     behaviorHints: {
       configurable: !configured,
       configurationRequired: !configured,

--- a/backend/src/routes/catalog.ts
+++ b/backend/src/routes/catalog.ts
@@ -6,7 +6,7 @@ import { StremioMediaType, validateStremioMediaType } from "@/lib/mediaTypes";
 
 // Cache for 5 minute
 const setCacheControl = (res: Response) => {
-  if (getConfig().env) {
+  if (getConfig().env === "production") {
     res.set("Cache-Control", `public, max-age=${60 * 5}`);
   }
 };

--- a/backend/src/tmdb.ts
+++ b/backend/src/tmdb.ts
@@ -4,6 +4,7 @@ import getClient from "@/cache";
 import { CleanedTMDBMovie, CleanedTMDBShow } from "@/types";
 import { cleanTMDBMovieMeta, cleanTMDBShowMeta } from "@/utils";
 import { getConfig } from "./lib/config";
+import { StremioMediaType } from "./lib/mediaTypes";
 
 const TMDB_API = "https://api.themoviedb.org/3";
 
@@ -13,6 +14,21 @@ const tmdbAxios = axios.create({
     Authorization: `Bearer ${getConfig().tmdbApiKey}`,
   },
 });
+
+export async function getTMDBMeta(
+  tmdbId: string,
+  type: StremioMediaType,
+): Promise<CleanedTMDBMovie | CleanedTMDBShow | null> {
+  switch (type) {
+    case StremioMediaType.Series:
+    case String(StremioMediaType.Anime):
+      return getTMDBShowMeta(tmdbId);
+    case StremioMediaType.Movie:
+      return getTMDBMovieMeta(tmdbId);
+    default:
+      return null;
+  }
+}
 
 export async function getTMDBMovieMeta(
   tmdbId: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "stremio-simkl",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "concurrently": "^9.1.2"

--- a/shared/catalogs.ts
+++ b/shared/catalogs.ts
@@ -11,6 +11,9 @@ export enum CatalogType {
   SERIES_WATCHING = "simkl-watching",
   SERIES_PLAN_TO_WATCH = "simkl-plan-to-watch-series",
   SERIES_COMPLETED = "simkl-completed-series",
+  ANIME_WATCHING = "simkl-watching-anime",
+  ANIME_PLAN_TO_WATCH = "simkl-plan-to-watch-anime",
+  ANIME_COMPLETED = "simkl-completed-anime",
 }
 
 export const allCatalogs = Object.values(CatalogType);
@@ -27,6 +30,9 @@ export const frontendCatalogNames: Record<CatalogType, string> = {
   [CatalogType.SERIES_WATCHING]: "Series Watching",
   [CatalogType.SERIES_PLAN_TO_WATCH]: "Series Plan To Watch",
   [CatalogType.SERIES_COMPLETED]: "Series Completed",
+  [CatalogType.ANIME_WATCHING]: "Anime Watching",
+  [CatalogType.ANIME_PLAN_TO_WATCH]: "Anime Plan To Watch",
+  [CatalogType.ANIME_COMPLETED]: "Anime Completed",
 };
 
 export const catalogToInt = (catalog: CatalogType) => {
@@ -61,6 +67,24 @@ export const catalogsData = {
   [CatalogType.SERIES_COMPLETED]: {
     id: CatalogType.SERIES_COMPLETED,
     type: "series",
+    name: "SIMKL Completed",
+    extra: catalogExtra,
+  },
+  [CatalogType.ANIME_WATCHING]: {
+    id: CatalogType.ANIME_WATCHING,
+    type: "anime",
+    name: "SIMKL Watching",
+    extra: catalogExtra,
+  },
+  [CatalogType.ANIME_PLAN_TO_WATCH]: {
+    id: CatalogType.ANIME_PLAN_TO_WATCH,
+    type: "anime",
+    name: "SIMKL Plan To Watch",
+    extra: catalogExtra,
+  },
+  [CatalogType.ANIME_COMPLETED]: {
+    id: CatalogType.ANIME_COMPLETED,
+    type: "anime",
     name: "SIMKL Completed",
     extra: catalogExtra,
   },


### PR DESCRIPTION
Closes #3 

Currently, only the first season of each anime is supported. This is because only the first season contains the IMDB ID required for Stremio's Cinemeta add-on.